### PR TITLE
generalize ResNet to all tasks

### DIFF
--- a/experiments/model_development/config/config.yaml
+++ b/experiments/model_development/config/config.yaml
@@ -5,7 +5,6 @@ model:
   cnn_architecture: "resnet18"
   lstm_num_layers: 2
   lstm_hidden_size: 512
-  num_classes: 3
 
 data_loader:
   batch_size: 1

--- a/experiments/model_development/utils/translators.py
+++ b/experiments/model_development/utils/translators.py
@@ -1,32 +1,55 @@
 """
-translators.py: contains definitions of functions used to translate classes from different expts into zero-indexed integers.
+translators.py: contains definitions of dictionaries used to translate classes from different experiments into zero-indexed integers.
 """
 
-# Translator for the Shape experiment
-def SHAPE(label):
-    return {
-        -1: 0,
-        1: 1
-    }[label]
+# Shape
+SHAPE_DICT = {
+    -1: 0,
+    1: 1,
+}
 
-# Translator for the Gravity Bias experiment
-def GRAVITY(label):
-    return {
-        0: 0,
-        1: 1,
-        2: 2
-    }[label]
+# Gravity Bias
+GRAVITY_DICT = {
+    0: 0,
+    1: 1,
+    2: 2,
+    3: 3,
+    4: 4,
+    5: 5,
+}
 
-# Translator for the Simple Swap experiment
-def SWAP(label):
-    return {
-        "left": 0,
-        "middle": 1,
-        "right": 2
-    }[label]
+# Simple Swap
+SWAP_DICT = {
+    "left": 0,
+    "middle": 1,
+    "right": 2,
+}
 
-expts = {
-    "shape": SHAPE,
-    "gravity": GRAVITY,
-    "swap": SWAP
-    }
+# Rotation
+ROTATION_DICT = {
+    "left": 0,
+    "middle": 1,
+    "right": 2,
+}
+
+# Addition Numbers
+ADDITION_DICT = {
+    "left": 0,
+    "equal": 1,
+    "right": 2,
+}
+
+# Relative Numbers
+RELATIVE_DICT = {
+    "left": 0,
+    "right": 1,
+}
+
+expt_dicts = {
+    "shape": SHAPE_DICT,
+    "gravity": GRAVITY_DICT,
+    "swap": SWAP_DICT,
+    "rotation": ROTATION_DICT,
+    "addition": ADDITION_DICT,
+    "relative": RELATIVE_DICT,
+}


### PR DESCRIPTION
This PR generalizes a baseline for the ResNet-backbone model to enable training on all Simulated Cognitive Battery tasks, not just `Shape`, for all training parameter values.